### PR TITLE
fix: docs command / add missing deps

### DIFF
--- a/docs/running-with-napalm.md
+++ b/docs/running-with-napalm.md
@@ -27,7 +27,7 @@ $ pip3 install napalm-core
 Now, let’s see what you get from this package:
 
 ```bash
-$ napalm collections show
+$ napalm collections list
 <installation prompt>
 Installed collections:
   - napalm-core/optimisations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ importlib-metadata = "^7.0.0"
 rich = "^13.7.0"
 langchain = "^0.0.352"
 openai = "^1.6.1"
-
+setuptools = "69.1.1"
+semgrep = "1.63.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.11.0"


### PR DESCRIPTION
Reference: https://github.com/ConsenSysDiligence/napalm/issues/5

`napalm collections show` requires `TARGET`, I think intention in docs was to use `list` command.

I added two missing dependencies to `pyproject.toml`. Without `semgrep` installed you can't use `detect` workflow. Without `setuptools` it's `napalm-slither` that fails to execute. I used most current versions of packages available.