### PR TITLE
Removed backlashes inside evaluations that are inside f-strings

### DIFF
--- a/napalm/cli/base/collection.py
+++ b/napalm/cli/base/collection.py
@@ -49,8 +49,9 @@ def show(ctx, collection: str):
     tool_rules["semgrep"] = semgrep_rules
 
     for detector in detectors:
+        short_description = detector.short_description.rstrip('\n')
         console.print(
-            f"[blue]{detector.id}[/blue] - [{detector.severity}] [green]{detector.short_description.rstrip('\n')}[/green]"
+            f"[blue]{detector.id}[/blue] - [{detector.severity}] [green]{short_description}[/green]"
         )
 
     # summary

--- a/napalm/cli/dev/info.py
+++ b/napalm/cli/dev/info.py
@@ -39,9 +39,10 @@ def _print_terminal_report(package_name, collections):
     for collection in collections:
         console.print(f"\n[cyan]{collection.collection_name}[/cyan] modules:")
         for detector in collection.detectors:
+            short_description = detector.short_description.rstrip('\n')
             console.print(
                 f"  - [blue]{detector.id}[/blue] - [{detector.severity}]"
-                f" [green]{detector.short_description.rstrip('\n')}[/green]"
+                f" [green]{short_description}[/green]"
             )
 
 
@@ -66,8 +67,9 @@ def _print_markdown_report(package_name, collections):
         console.print(f"  | ID | Description | Severity |")
         console.print(f"  | ------ | ----------- | -------- |")
         for detector in collection.detectors:
+            short_description = detector.short_description.rstrip('\n')
             console.print(
-                f"  | {detector.id} | {detector.short_description.rstrip('\n')} | {detector.severity} |"
+                f"  | {detector.id} | {short_description} | {detector.severity} |"
             )
 
 

--- a/napalm/report/simple_report.py
+++ b/napalm/report/simple_report.py
@@ -26,6 +26,7 @@ class SimpleReporter:
         # print all issues found
         for run in report.runs:
             for finding in run.results:
+                message = finding.message.text.rstrip('\n')
                 console.print(
-                    f"[red]Found issue: {finding.message.text.rstrip('\n')}[/red]"
+                    f"[red]Found issue: {message}[/red]"
                 )


### PR DESCRIPTION
Adds backward compatibility to older Python versions. Solves #9.

I haven't thoroughly tested this, but it should be fine.